### PR TITLE
Allow calling RegisterInterruptCallback more than once

### DIFF
--- a/src/Unosquare.RaspberryIO/Gpio/GpioPin.cs
+++ b/src/Unosquare.RaspberryIO/Gpio/GpioPin.cs
@@ -607,17 +607,12 @@
         /// <param name="callback">The callback.</param>
         /// <exception cref="ArgumentException">callback.</exception>
         /// <exception cref="InvalidOperationException">
-        /// An interrupt callback was already registered.
-        /// or
         /// RegisterInterruptCallback.
         /// </exception>
         public void RegisterInterruptCallback(EdgeDetection edgeDetection, InterruptServiceRoutineCallback callback)
         {
             if (callback == null)
                 throw new ArgumentException($"{nameof(callback)} cannot be null");
-
-            if (InterruptCallback != null)
-                throw new InvalidOperationException("An interrupt callback was already registered.");
 
             if (PinMode != GpioPinDriveMode.Input)
             {


### PR DESCRIPTION
WiringPi will call the gpio utility to change edge detection and replace any existing ISR callback with the one provided. This has been verified by reading the WiringPi ISR code as well as by testing.