### PR TITLE
Fix Terminal display

### DIFF
--- a/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Button.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Button.cs
@@ -1,8 +1,6 @@
 namespace Unosquare.RaspberryIO.Playground.Extra
 {
     using Abstractions;
-    using Swan;
-    using Swan.Logging;
     using System;
     using Unosquare.RaspberryIO.Peripherals;
 
@@ -12,7 +10,6 @@ namespace Unosquare.RaspberryIO.Playground.Extra
         {
             Console.Clear();
 
-            "Testing Button".Info();
             var inputPin = Pi.Gpio[BcmPin.Gpio12];
             var button = new Button(inputPin, GpioPinResistorPullMode.PullUp);
 
@@ -32,8 +29,8 @@ namespace Unosquare.RaspberryIO.Playground.Extra
         private static void LogMessageOnEvent(string message)
         {
             Console.Clear();
-            message.Info();
-            Terminal.WriteLine(ExitMessage);
+            Console.WriteLine(message);
+            Console.WriteLine(ExitMessage);
         }
     }
 }

--- a/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Led.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Led.cs
@@ -2,7 +2,6 @@ namespace Unosquare.RaspberryIO.Playground.Extra
 {
     using Abstractions;
     using Swan;
-    using Swan.Logging;
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -71,8 +70,8 @@ namespace Unosquare.RaspberryIO.Playground.Extra
                     blinkingPin.Write(isOn);
                     var ledState = isOn ? "on" : "off";
                     Console.Clear();
-                    $"Blinking {ledState}".Info();
-                    Terminal.WriteLine(ExitMessage);
+                    Console.WriteLine($"Blinking {ledState}");
+                    Console.WriteLine(ExitMessage);
                     Thread.Sleep(500);
                 }
 
@@ -84,7 +83,7 @@ namespace Unosquare.RaspberryIO.Playground.Extra
             Task.Run(async () =>
             {
                 Console.Clear();
-                "Hardware Dimming".Info();
+                Console.WriteLine("Hardware Dimming");
                 Terminal.WriteLine(ExitMessage);
 
                 var pin = (GpioPin)Pi.Gpio[BcmPin.Gpio13];
@@ -118,7 +117,7 @@ namespace Unosquare.RaspberryIO.Playground.Extra
             Task.Run(async () =>
             {
                 Console.Clear();
-                "Dimming".Info();
+                Console.WriteLine("Software Dimming");
                 Terminal.WriteLine(ExitMessage);
 
                 var pinGreen = (GpioPin)Pi.Gpio[BcmPin.Gpio23];

--- a/src/Unosquare.RaspberryIO.Playground/Extra/Extra.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Extra/Extra.cs
@@ -1,8 +1,8 @@
 namespace Unosquare.RaspberryIO.Playground.Extra
 {
+    using Swan;
     using System;
     using System.Collections.Generic;
-    using Swan;
 
     public static partial class Extra
     {

--- a/src/Unosquare.RaspberryIO.Playground/Extra/PiOled.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Extra/PiOled.cs
@@ -1,4 +1,4 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Extra
+namespace Unosquare.RaspberryIO.Playground.Extra
 {
     using System;
     using System.Diagnostics;
@@ -6,7 +6,6 @@
     using System.Drawing.Drawing2D;
     using System.Drawing.Imaging;
     using System.Threading;
-    using Swan.Logging;
     using Swan.Threading;
     using Unosquare.RaspberryIO.Peripherals;
 
@@ -81,7 +80,7 @@
                 {
                     var elapsedSeconds = sw.Elapsed.TotalSeconds;
                     var framesPerSecond = frameCount / elapsedSeconds;
-                    $"Contrast: {_display.Contrast}. X: {currentX} Y: {currentY} Frames: {cycleCount:0} Elapsed {elapsedSeconds:0.000} FPS: {framesPerSecond:0.000}".Info(Name);
+                    Console.WriteLine($"Contrast: {_display.Contrast}. X: {currentX} Y: {currentY} Frames: {cycleCount:0} Elapsed {elapsedSeconds:0.000} FPS: {framesPerSecond:0.000}");
                     sw.Restart();
                     frameCount = 0;
                     currentX = 0;

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Accelerometer.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Accelerometer.cs
@@ -1,8 +1,7 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using Swan;
-    using Swan.Logging;
     using Unosquare.RaspberryIO.Peripherals;
 
     public static partial class Peripherals
@@ -25,9 +24,8 @@
                     (s, e) =>
                     {
                         Console.Clear();
-                        $"\nAccelerometer:\n{e.Accel}\n\nGyroscope:\n{e.Gyro}\n\nTemperature: {Math.Round(e.Temperature, 2)}°C\n"
-                            .Info("GY-521");
-                        Terminal.WriteLine(ExitMessage);
+                        Console.WriteLine($"GY521 Accelerometer:\n{e.Accel}\n\nGyroscope:\n{e.Gyro}\n\nTemperature: {Math.Round(e.Temperature, 2)}°C\n");
+                        Console.WriteLine(ExitMessage);
                     };
 
                 // Run accelerometer

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.IR.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.IR.cs
@@ -1,8 +1,7 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using Swan;
-    using Swan.Logging;
     using Abstractions;
     using Unosquare.RaspberryIO.Peripherals;
 
@@ -14,7 +13,7 @@
         public static void TestInfraredSensor()
         {
             Console.Clear();
-            "Send a signal...".Info("IR");
+            Console.WriteLine("Send a signal...");
             var inputPin = Pi.Gpio[BcmPin.Gpio25]; // BCM Pin 25 or Physical pin 22 on the right side of the header.
             var sensor = new InfraredSensor(inputPin, true);
 
@@ -24,7 +23,7 @@
                    var necData = InfraredSensor.NecDecoder.DecodePulses(e.Pulses);
                    if (necData != null)
                    {
-                       $"NEC Data: {BitConverter.ToString(necData).Replace("-", " "),12}    Pulses: {e.Pulses.Length,4}    Duration(us): {e.TrainDurationUsecs,6}    Reason: {e.FlushReason}".Warn("IR");
+                       Console.WriteLine($"NEC Data: {BitConverter.ToString(necData).Replace("-", " "),12}    Pulses: {e.Pulses.Length,4}    Duration(us): {e.TrainDurationUsecs,6}    Reason: {e.FlushReason}");
 
                        if (InfraredSensor.NecDecoder.IsRepeatCode(e.Pulses))
                            return;
@@ -34,16 +33,16 @@
                        if (e.Pulses.Length >= 4)
                        {
                            var debugData = InfraredSensor.DebugPulses(e.Pulses);
-                           $"RX    Length: {e.Pulses.Length,5}; Duration: {e.TrainDurationUsecs,7}; Reason: {e.FlushReason}".Warn("IR");
-                           debugData.Info("IR");
+                           Console.WriteLine($"RX    Length: {e.Pulses.Length,5}; Duration: {e.TrainDurationUsecs,7}; Reason: {e.FlushReason}");
+                           Console.WriteLine($"Debug data: {debugData}");
                        }
                        else
                        {
-                           $"RX (Garbage): {e.Pulses.Length,5}; Duration: {e.TrainDurationUsecs,7}; Reason: {e.FlushReason}".Error("IR");
+                           Console.WriteLine($"RX (Garbage): {e.Pulses.Length,5}; Duration: {e.TrainDurationUsecs,7}; Reason: {e.FlushReason}");
                        }
                    }
 
-                   Terminal.WriteLine(ExitMessage);
+                   Console.WriteLine(ExitMessage);
                };
 
             while (true)

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.LedStrip.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.LedStrip.cs
@@ -1,4 +1,4 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using System.Collections.Generic;
@@ -6,7 +6,6 @@
     using System.Linq;
     using System.Threading;
     using Swan;
-    using Swan.Logging;
     using Unosquare.RaspberryIO.Peripherals;
 
     public static partial class Peripherals
@@ -23,14 +22,14 @@
                 using (var bitmap =
                     new System.Drawing.Bitmap(Path.Combine(SwanRuntime.EntryAssemblyDirectory, "fractal.jpg")))
                 {
-                    $"Loaded bitmap with format {bitmap.PixelFormat}".Info();
+                    Console.WriteLine($"Loaded bitmap with format {bitmap.PixelFormat}");
                     pixels = new BitmapBuffer(bitmap);
-                    $"Loaded Pixel Data: {pixels.Data.Length} bytes".Info();
+                    Console.WriteLine($"Loaded Pixel Data: {pixels.Data.Length} bytes");
                 }
             }
             catch (Exception ex)
             {
-                $"Error Loading image: {ex.Message}".Error();
+                Console.WriteLine($"Error Loading image: {ex.Message}");
             }
 
             var exitAnimation = false;
@@ -78,7 +77,7 @@
                     if (delayMilliseconds > 0 && exitAnimation == false)
                         Thread.Sleep(delayMilliseconds);
                     else
-                        $"Lagging frame rate: {delayMilliseconds} milliseconds".Info();
+                        Console.WriteLine($"Lagging frame rate: {delayMilliseconds} milliseconds");
 
                     frameTimes.Enqueue((int)DateTime.UtcNow.Subtract(lastRenderTime).TotalMilliseconds);
                     lastRenderTime = DateTime.UtcNow;
@@ -98,8 +97,7 @@
                 strip.Render();
 
                 var avg = frameRenderTimes.Average();
-                $"Frames: {currentFrameNumber + 1}, FPS: {Math.Round(1000f / frameTimes.Average(), 3)}, Strip Render: {Math.Round(avg, 3)} ms, Max FPS: {Math.Round(1000 / avg, 3)}"
-                    .Info();
+                Console.WriteLine($"Frames: {currentFrameNumber + 1}, FPS: {Math.Round(1000f / frameTimes.Average(), 3)}, Strip Render: {Math.Round(avg, 3)} ms, Max FPS: {Math.Round(1000 / avg, 3)}");
                 strip.Render();
             });
 
@@ -148,7 +146,7 @@
                     }
                     else
                     {
-                        $"Lagging framerate: {delayMilliseconds} milliseconds".Info();
+                        Console.WriteLine($"Lagging framerate: {delayMilliseconds} milliseconds");
                     }
 
                     lastRenderTime = DateTime.UtcNow;

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Rfid.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Rfid.cs
@@ -1,11 +1,10 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using Swan;
-    using Swan.Logging;
     using Unosquare.RaspberryIO.Peripherals;
 
     public static partial class Peripherals
@@ -54,14 +53,14 @@
         /// </summary>
         public static void TestRfidController()
         {
-            "Testing RFID".Info();
+            Console.WriteLine("Testing RFID");
             var device = new RFIDControllerMfrc522(Pi.Spi.Channel0, 500000, Pi.Gpio[18]);
 
             while (true)
             {
                 // If a card is found
                 if (device.DetectCard() != RFIDControllerMfrc522.Status.AllOk) continue;
-                "Card detected".Info();
+                Console.WriteLine("Card detected");
 
                 // Get the UID of the card
                 var uidResponse = device.ReadCardUniqueId();
@@ -72,7 +71,7 @@
                 var cardUid = uidResponse.Data;
 
                 // Print UID
-                $"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}".Info();
+                Console.WriteLine($"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}");
 
                 // Select the scanned tag
                 device.SelectCardUniqueId(cardUid);
@@ -100,7 +99,7 @@
                     // Authenticate sector
                     if (device.AuthenticateCard1A(RFIDControllerMfrc522.DefaultAuthKey, cardUid, (byte)((4 * s) + 3)) == RFIDControllerMfrc522.Status.AllOk)
                     {
-                        $"Sector {s}".Info();
+                        Console.WriteLine($"Sector {s}");
                         for (var b = 0; b < 3 && continueReading; b++)
                         {
                             var data = device.CardReadData((byte)((4 * s) + b));
@@ -110,12 +109,12 @@
                                 break;
                             }
 
-                            $"  Block {b} ({data.Data.Length} bytes): {string.Join(" ", data.Data.Select(x => x.ToString("X2")))}".Info();
+                            Console.WriteLine($"  Block {b} ({data.Data.Length} bytes): {string.Join(" ", data.Data.Select(x => x.ToString("X2")))}");
                         }
                     }
                     else
                     {
-                        "Authentication error".Error();
+                        Console.WriteLine("Authentication error");
                         break;
                     }
                 }
@@ -127,14 +126,14 @@
         private static void CardDetected()
         {
             Console.Clear();
-            "Testing RFID".Info();
+            Console.WriteLine("Testing RFID");
             var device = new RFIDControllerMfrc522(Pi.Spi.Channel0, 500000, Pi.Gpio[18]);
 
             while (true)
             {
                 // If a card is found
                 if (device.DetectCard() != RFIDControllerMfrc522.Status.AllOk) continue;
-                "Card detected".Info();
+                Console.WriteLine("Card detected");
 
                 // Get the UID of the card
                 var uidResponse = device.ReadCardUniqueId();
@@ -145,7 +144,7 @@
                 var cardUid = uidResponse.Data;
 
                 // Print UID
-                $"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}".Info();
+                Console.WriteLine($"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}");
 
                 Terminal.WriteLine(ExitMessage);
 
@@ -163,12 +162,12 @@
 
         private static void WriteCard()
         {
-            Console.Clear();
-            "Testing RFID".Info();
+            Terminal.Clear();
+            Terminal.WriteLine("Testing RFID");
 
             var device = new RFIDControllerMfrc522(Pi.Spi.Channel0, 500000, Pi.Gpio[18]);
             var userInput = Terminal.ReadLine("Insert a message to be written in the card (16 characters only)").Truncate(16);
-            "Place the card on the sensor".Info();
+            Terminal.WriteLine("Place the card on the sensor");
 
             while (true)
             {
@@ -195,7 +194,7 @@
                 }
 
                 device.ClearCardSelection();
-                "Data has been written".Info();
+                Terminal.WriteLine("Data has been written");
 
                 Terminal.WriteLine(ExitMessage);
 
@@ -214,7 +213,7 @@
         private static void ReadCard()
         {
             Console.Clear();
-            "Testing RFID".Info();
+            Console.WriteLine("Testing RFID");
             var device = new RFIDControllerMfrc522(Pi.Spi.Channel0, 500000, Pi.Gpio[18]);
 
             while (true)
@@ -231,7 +230,7 @@
                 var cardUid = uidResponse.Data;
 
                 // Print UID
-                $"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}".Info();
+                Console.WriteLine($"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}");
 
                 // Select the scanned tag
                 device.SelectCardUniqueId(cardUid);
@@ -242,11 +241,11 @@
                     var data = device.CardReadData(16);
                     var text = Encoding.ASCII.GetString(data.Data);
 
-                    $" Message read: {text}".Info();
+                    Console.WriteLine($" Message read: {text}");
                 }
                 else
                 {
-                    "Authentication error".Error();
+                    Console.WriteLine("Authentication error");
                 }
 
                 device.ClearCardSelection();
@@ -268,7 +267,7 @@
         {
             Console.Clear();
 
-            "Testing RFID".Info();
+            Console.WriteLine("Testing RFID");
             var device = new RFIDControllerMfrc522(Pi.Spi.Channel0, 500000, Pi.Gpio[18]);
 
             while (true)
@@ -285,7 +284,7 @@
                 var cardUid = uidResponse.Data;
 
                 // Print UID
-                $"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}".Info();
+                Console.WriteLine($"Card UID: {cardUid[0]},{cardUid[1]},{cardUid[2]},{cardUid[3]}");
 
                 // Select the scanned tag
                 device.SelectCardUniqueId(cardUid);
@@ -297,7 +296,7 @@
                     // Authenticate sector
                     if (device.AuthenticateCard1A(RFIDControllerMfrc522.DefaultAuthKey, cardUid, (byte)((4 * s) + 3)) == RFIDControllerMfrc522.Status.AllOk)
                     {
-                        $"Sector {s}".Info();
+                        Console.WriteLine($"Sector {s}");
                         for (var b = 0; b < 3 && continueReading; b++)
                         {
                             var data = device.CardReadData((byte)((4 * s) + b));
@@ -307,12 +306,12 @@
                                 break;
                             }
 
-                            $"  Block {b} ({data.Data.Length} bytes): {string.Join(" ", data.Data.Select(x => x.ToString("X2")))}".Info();
+                            Console.WriteLine($"  Block {b} ({data.Data.Length} bytes): {string.Join(" ", data.Data.Select(x => x.ToString("X2")))}");
                         }
                     }
                     else
                     {
-                        $"Authentication error, sector {s}".Error();
+                        Console.WriteLine($"Authentication error, sector {s}");
                     }
                 }
 

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.TempHum.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.TempHum.cs
@@ -1,8 +1,6 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
-    using Swan;
-    using Swan.Logging;
     using Abstractions;
     using Unosquare.RaspberryIO.Peripherals;
 
@@ -10,6 +8,8 @@
     {
         /// <summary>
         /// Tests the temperature sensor.
+        /// The DHT11 sensor, also available as KY-015 for usage on experimental boards, needs to be connected to Gpio04 (physical pin 7) with its
+        /// single data line. The sensor has a conspicuous blue grid-shaped housing. 
         /// </summary>
         public static void TestTempSensor()
         {
@@ -23,12 +23,15 @@
                 sensor.OnDataAvailable += (s, e) =>
                 {
                     totalReadings++;
-                    if (!e.IsValid) return;
+                    if (!e.IsValid)
+                        return;
 
                     Console.Clear();
                     validReadings++;
-                    $"Temperature: \n {e.Temperature:0.00}°C \n {e.TemperatureFahrenheit:0.00}°F  \n Humidity: {e.HumidityPercentage:P0}\n\n".Info("DHT11");
-                    Terminal.WriteLine(ExitMessage);
+                    Console.WriteLine($"DHT11 Temperature: \n {e.Temperature:0.00}°C \n {e.TemperatureFahrenheit:0.00}°F  \n Humidity: {e.HumidityPercentage:P0}\n\n");
+                    Console.WriteLine($"      Number of valid data samples received: {validReadings} of {totalReadings}");
+                    Console.WriteLine();
+                    Console.WriteLine(ExitMessage);
                 };
 
                 sensor.Start();

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Ultrasonic.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Ultrasonic.cs
@@ -1,9 +1,8 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using Abstractions;
     using Swan;
-    using Swan.Logging;
     using Unosquare.RaspberryIO.Peripherals;
 
     public static partial class Peripherals
@@ -21,7 +20,7 @@
             {
                 sensor.OnDataAvailable += (s, e) =>
                 {
-                    Console.Clear();
+                    Terminal.Clear();
 
                     if (!e.IsValid)
                     {
@@ -60,7 +59,7 @@
                 sensor.Start();
                 while (true)
                 {
-                    var input = Console.ReadKey(true).Key;
+                    var input = Terminal.ReadKey(true).Key;
                     if (input != ConsoleKey.Escape) continue;
 
                     break;

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.cs
@@ -1,4 +1,4 @@
-﻿namespace Unosquare.RaspberryIO.Playground.Peripherals
+namespace Unosquare.RaspberryIO.Playground.Peripherals
 {
     using System;
     using System.Collections.Generic;

--- a/src/Unosquare.RaspberryIO.Playground/Program.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Program.cs
@@ -1,10 +1,9 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Swan;
     using Swan.Logging;
+    using System;
+    using System.Collections.Generic;
     using WiringPi;
 
     /// <summary>
@@ -23,23 +22,23 @@
         /// <summary>
         /// Defines the entry point of the application.
         /// </summary>
-        /// <returns>A task representing the program.</returns>
-        public static async Task Main()
+        public static void Main()
         {
-            $"Starting program at {DateTime.Now}".Info();
-
+            // We shouldn't be logging to the console in a console app that is user-interactive
+            Swan.Logging.Logger.UnregisterLogger<ConsoleLogger>();
             Pi.Init<BootstrapWiringPi>();
 
             var exit = false;
             do
             {
                 Console.Clear();
+                Console.CursorVisible = true;
                 var mainOption = Terminal.ReadPrompt("Main options", MainOptions, "Esc to exit this program");
-
+                Console.CursorVisible = true;
                 switch (mainOption.Key)
                 {
                     case ConsoleKey.S:
-                        await SystemTests.ShowMenu().ConfigureAwait(false);
+                        SystemTests.ShowMenu();
                         break;
                     case ConsoleKey.P:
                         Peripherals.Peripherals.ShowMenu();
@@ -55,6 +54,8 @@
             while (!exit);
 
             Console.Clear();
+            Console.CursorVisible = true;
+            Console.ResetColor();
         }
     }
 }

--- a/src/Unosquare.RaspberryIO.Playground/System/System.Info.cs
+++ b/src/Unosquare.RaspberryIO.Playground/System/System.Info.cs
@@ -1,46 +1,48 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
     using Computer;
-    using Swan;
-    using Swan.Logging;
     using System;
     using System.Linq;
-    using System.Threading.Tasks;
 
     public static partial class SystemTests
     {
-        private static async Task TestSystemInfo()
+        private static void TestSystemInfo()
         {
             Console.Clear();
 
-            $"GPIO Controller initialized successfully with {Pi.Gpio.Count} pins".Info();
-            $"{Pi.Info}".Info();
+            Console.WriteLine($"GPIO Controller initialized successfully with {Pi.Gpio.Count} pins");
+            Console.WriteLine($"{Pi.Info}");
 
             try
             {
-                $"BoardModel {Pi.Info.BoardModel}".Info();
-                $"ProcessorModel {Pi.Info.ProcessorModel}".Info();
-                $"Manufacturer {Pi.Info.Manufacturer}".Info();
-                $"MemorySize {Pi.Info.MemorySize}".Info();
+                Console.WriteLine($"BoardModel {Pi.Info.BoardModel}");
+                Console.WriteLine($"ProcessorModel {Pi.Info.ProcessorModel}");
+                Console.WriteLine($"Manufacturer {Pi.Info.Manufacturer}");
+                Console.WriteLine($"MemorySize {Pi.Info.MemorySize}");
             }
-            catch
+            catch (Exception x)
             {
-                // ignore
+                Console.WriteLine("Error obtaining system configuration: " + x.Message);
             }
 
-            $"Uname {Pi.Info.OperatingSystem}".Info();
-            $"HostName {NetworkSettings.Instance.HostName}".Info();
-            $"Uptime (seconds) {Pi.Info.Uptime}".Info();
-            var timeSpan = Pi.Info.UptimeTimeSpan;
-            $"Uptime (timespan) {timeSpan.Days} days {timeSpan.Hours:00}:{timeSpan.Minutes:00}:{timeSpan.Seconds:00}"
-                .Info();
+            try
+            {
+                Console.WriteLine($"Uname {Pi.Info.OperatingSystem}");
+                Console.WriteLine($"HostName {NetworkSettings.Instance.HostName}");
+                Console.WriteLine($"Uptime (seconds) {Pi.Info.Uptime}");
+                var timeSpan = Pi.Info.UptimeTimeSpan;
+                Console.WriteLine($"Uptime (timespan) {timeSpan.Days} days {timeSpan.Hours:00}:{timeSpan.Minutes:00}:{timeSpan.Seconds:00}");
 
-            (await NetworkSettings.Instance.RetrieveAdapters().ConfigureAwait(false))
-                .Select(adapter => $"Adapter: {adapter.Name,6} | IPv4: {adapter.IPv4,16} | IPv6: {adapter.IPv6,28} | AP: {adapter.AccessPointName,16} | MAC: {adapter.MacAddress,18}")
-                .ToList()
-                .ForEach(x => x.Info());
-
-            Terminal.WriteLine(ExitMessage);
+                var adapters = NetworkSettings.Instance.RetrieveAdapters();
+                adapters.Result.Select(adapter => $"Adapter: {adapter.Name,6} | IPv4: {adapter.IPv4,16} | IPv6: {adapter.IPv6,28} | AP: {adapter.AccessPointName,16} | MAC: {adapter.MacAddress,18}")
+                    .ToList()
+                    .ForEach(x => Console.WriteLine(x));
+            }
+            catch(Exception x)
+            {
+                Console.WriteLine("Error retrieving network interface settings: " + x.Message);
+            }
+            Console.WriteLine(ExitMessage);
 
             while (true)
             {

--- a/src/Unosquare.RaspberryIO.Playground/System/SystemCamera.cs
+++ b/src/Unosquare.RaspberryIO.Playground/System/SystemCamera.cs
@@ -1,8 +1,7 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
     using Camera;
     using Swan;
-    using Swan.Logging;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
@@ -41,7 +40,7 @@
 
         private static void CaptureImage()
         {
-            Console.Clear();
+            Terminal.Clear();
 
             var imageWidth = Terminal.ReadNumber("Set the image width:", 640);
             var imageHeight = Terminal.ReadNumber("Set the image height:", 480);
@@ -54,12 +53,12 @@
 
             File.WriteAllBytes(targetPath, pictureBytes);
 
-            $"Picture taken: {fileName}.jpg".Info();
-            $"Size: {pictureBytes.Length}B".Info();
-            $"Date Created: {DateTime.Now:MM/dd/yyyy}".Info();
-            $"At {DefaultPicturePath}\n".Info();
+            Console.WriteLine($"Picture taken: {fileName}.jpg");
+            Console.WriteLine($"Size: {pictureBytes.Length}B");
+            Console.WriteLine($"Date Created: {DateTime.Now:MM/dd/yyyy}");
+            Console.WriteLine($"At {DefaultPicturePath}\n");
 
-            Terminal.WriteLine("Press Esc key to continue . . .");
+            Console.WriteLine("Press Esc key to continue . . .");
 
             while (true)
             {
@@ -95,7 +94,7 @@
                 VideoFileName = $"{DefaultPicturePath}/{videoPath}.h264",
             };
 
-            "Press any key to START recording . . .".Info();
+            Console.WriteLine("Press any key to START recording . . .");
             Console.ReadLine();
             Console.Clear();
             var startTime = DateTime.UtcNow;
@@ -120,8 +119,8 @@
 
             var megaBytesReceived = (videoByteCount / (1024f * 1024f)).ToString("0.000", CultureInfo.InvariantCulture.NumberFormat);
             var recordedSeconds = DateTime.UtcNow.Subtract(startTime).TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture.NumberFormat);
-            "Recording stopped. . .\n\n".Info();
-            $"Recorded {megaBytesReceived}MB\n{videoEventCount} callbacks\nRecorded {recordedSeconds} seconds\nCreated {DateTime.Now}\nAt {videoSettings.VideoFileName}\n\n".Info();
+            Console.WriteLine("Recording stopped. . .\n\n");
+            Console.WriteLine($"Recorded {megaBytesReceived}MB\n{videoEventCount} callbacks\nRecorded {recordedSeconds} seconds\nCreated {DateTime.Now}\nAt {videoSettings.VideoFileName}\n\n");
         }
     }
 }

--- a/src/Unosquare.RaspberryIO.Playground/System/SystemDisplay.cs
+++ b/src/Unosquare.RaspberryIO.Playground/System/SystemDisplay.cs
@@ -1,23 +1,32 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
+    using Swan;
     using Swan.Logging;
     using System;
-    using System.Threading.Tasks;
+    using System.Collections.Generic;
 
+    /// <summary>
+    /// Manipulates settings for the default 7" Raspberry display. Will probably not work with displays connected trough HDMI. 
+    /// </summary>
     public static class SystemDisplay
     {
-        public static async Task ShowMenu()
+        private static readonly Dictionary<ConsoleKey, string> ScreenOptions = new Dictionary<ConsoleKey, string>
+        {
+            { ConsoleKey.B, "Set Brightness" },
+            { ConsoleKey.L, "Toggle backlight" },
+        };
+        public static void ShowMenu()
         {
             var exit = false;
 
             while (!exit)
             {
-                Console.Clear();
+                Terminal.Clear();
+                Terminal.WriteLine($"Brightness: {Pi.PiDisplay.Brightness}");
+                Terminal.WriteLine($"Backlight: [{(Pi.PiDisplay.IsBacklightOn ? (char)0x2714 : (char)0x2718)}]\n");
+                var mainOption = Terminal.ReadPrompt("System", ScreenOptions, "Esc to exit this menu");
 
-                $"Brightness: {Pi.PiDisplay.Brightness}".Info();
-                $"Blacklight: [{(Pi.PiDisplay.IsBacklightOn ? (char)0x2714 : (char)0x2718)}]\n".Info();
-
-                var key = Console.ReadKey(true).Key;
+                var key = mainOption.Key;
 
                 switch (key)
                 {
@@ -25,18 +34,11 @@
                         SetBrightness();
                         break;
                     case ConsoleKey.L:
-                        ToggleBlackLight();
+                        ToggleBackLight();
                         break;
                     case ConsoleKey.Escape:
                         exit = true;
                         break;
-                }
-
-                if (!exit)
-                {
-                    await Task.Delay(500).ConfigureAwait(false);
-                    Console.WriteLine("Press any key to continue . . .");
-                    Console.ReadKey(true);
                 }
             }
         }
@@ -69,7 +71,7 @@
             Pi.PiDisplay.Brightness = brightness;
         }
 
-        public static void ToggleBlackLight() =>
+        public static void ToggleBackLight() =>
             Pi.PiDisplay.IsBacklightOn = !Pi.PiDisplay.IsBacklightOn;
     }
 }

--- a/src/Unosquare.RaspberryIO.Playground/System/SystemTests.cs
+++ b/src/Unosquare.RaspberryIO.Playground/System/SystemTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
     using System;
     using System.Collections.Generic;
@@ -12,17 +12,18 @@
         private static readonly Dictionary<ConsoleKey, string> MainOptions = new Dictionary<ConsoleKey, string>
         {
             { ConsoleKey.C, "Camera" },
+            { ConsoleKey.D, "Display Brightness" },
             { ConsoleKey.I, "System Info" },
             { ConsoleKey.V, "Volume" },
         };
 
-        public static async Task ShowMenu()
+        public static void ShowMenu()
         {
             var exit = false;
 
             do
             {
-                Console.Clear();
+                Terminal.Clear();
                 var mainOption = Terminal.ReadPrompt("System", MainOptions, "Esc to exit this menu");
 
                 switch (mainOption.Key)
@@ -31,10 +32,14 @@
                         SystemCamera.ShowMenu();
                         break;
                     case ConsoleKey.I:
-                        await TestSystemInfo().ConfigureAwait(false);
+                        TestSystemInfo();
                         break;
                     case ConsoleKey.V:
-                        await SystemVolume.ShowMenu().ConfigureAwait(false);
+                        Task ret = SystemVolume.ShowMenu();
+                        ret.Wait();
+                        break;
+                    case ConsoleKey.D:
+                        SystemDisplay.ShowMenu();
                         break;
                     case ConsoleKey.Escape:
                         exit = true;

--- a/src/Unosquare.RaspberryIO.Playground/System/SystemVolume.cs
+++ b/src/Unosquare.RaspberryIO.Playground/System/SystemVolume.cs
@@ -1,15 +1,17 @@
-﻿namespace Unosquare.RaspberryIO.Playground
+namespace Unosquare.RaspberryIO.Playground
 {
     using System;
     using System.Threading.Tasks;
     using Swan;
-    using Swan.Logging;
 
     public static class SystemVolume
     {
         private static bool _mute;
         private static int CurrentLevel { get; set; }
 
+        /// <summary>
+        /// This shows how these commands can be used asynchronously, even though that is quite pointless for the demonstration application. 
+        /// </summary>
         public static async Task ShowMenu()
         {
             var exit = false;
@@ -19,18 +21,18 @@
                 var state = await Pi.Audio.GetState().ConfigureAwait(false);
                 CurrentLevel = state.Level;
 
-                Console.Clear();
-                $"\rControl name: {state.ControlName}".Info();
-                $"\rCard number: {state.CardNumber}".Info();
-                $"\rMute: [{(state.IsMute ? (char)0x2714 : (char)0x2718)}]\n".Info();
-                $"\rVolume level (dB): {state.Decibels}dB".Info();
+                Terminal.Clear();
+                Terminal.WriteLine($"\rControl name: {state.ControlName}");
+                Terminal.WriteLine($"\rCard number: {state.CardNumber}");
+                Terminal.WriteLine($"\rMute: [{(state.IsMute ? (char)0x2714 : (char)0x2718)}]\n");
+                Terminal.WriteLine($"\rVolume level (dB): {state.Decibels}dB");
 
                 UpdateProgress(CurrentLevel);
 
                 Terminal.WriteLine("Press UpArrow key to increment volume");
                 Terminal.WriteLine("Press DownArrow key to decrement volume");
                 Terminal.WriteLine("Press M key to Mute on/off\n");
-                var key = Terminal.ReadKey("Press Esc key to continue . . .").Key;
+                var key = Terminal.ReadKey(true).Key;
                 var validOption = false;
 
                 while (!validOption)
@@ -57,7 +59,7 @@
                     }
 
                     if (!validOption)
-                        key = Console.ReadKey(true).Key;
+                        key = Terminal.ReadKey(true).Key;
                 }
             }
         }

--- a/src/Unosquare.RaspberryIO.Playground/Unosquare.RaspberryIO.Playground.csproj
+++ b/src/Unosquare.RaspberryIO.Playground/Unosquare.RaspberryIO.Playground.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Unosquare.Swan.Lite" Version="2.3.0" />
+    <PackageReference Include="Unosquare.Swan.Lite" Version="2.4.0" />
     <PackageReference Include="Unosquare.WiringPi" Version="0.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Unosquare.RaspberryIO/Unosquare.RaspberryIO.csproj
+++ b/src/Unosquare.RaspberryIO/Unosquare.RaspberryIO.csproj
@@ -29,7 +29,7 @@ This library enables developers to use the various Raspberry Pi's hardware modul
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Unosquare.Swan" Version="2.3.1" />
+    <PackageReference Include="Unosquare.Swan" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Note: This isn't intended to be merged as-is without discussion

- The Swan.Terminal class seems to be written for special output devices (i.e LCD displays) that do not support unicode. On the default raspberry console, the border characters for the menus where completelly inappropriate. Also, some of the options where not visible. This now uses unicode border characters everywhere. (see attached image)
- The logging class also wrote to the terminal, interfering with direct output. A console application shouldn't use asynchronous (thread-based) console logging for direct user interaction. 
- Usages of async/await are not needed if nothing else needs to be done at the same time.
![grafik](https://user-images.githubusercontent.com/13809874/64921254-5a96c100-d7c1-11e9-84fb-46690c61bdbb.png)

I dindn't want to change Unosquare.Swan, since I don't know what that Terminal implementation was originally used/designed for. Maybe this needs to go there with a different name?
