### PR TITLE
ADS1115 support improved

### DIFF
--- a/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1015.cs
+++ b/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1015.cs
@@ -1,3 +1,5 @@
+using Unosquare.RaspberryIO.Abstractions;
+
 namespace Unosquare.RaspberryIO.Peripherals
 {
     /// <summary>
@@ -9,8 +11,8 @@ namespace Unosquare.RaspberryIO.Peripherals
         /// Initializes a new instance of the <see cref="ADS1015"/> class.
         /// </summary>
         /// <param name="address">The I2C Address for this device.</param>
-        public ADS1015(byte address = ADS1x15ADDRESS)
-            : base(ADS1015CONVERSIONDELAY, 4, address)
+        public ADS1015(II2CDevice device)
+            : base(device, ADS1015CONVERSIONDELAY, 4)
         {
         }
     }

--- a/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1115.cs
+++ b/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1115.cs
@@ -1,7 +1,10 @@
+using Unosquare.RaspberryIO.Abstractions;
+
 namespace Unosquare.RaspberryIO.Peripherals
 {
     /// <summary>
     /// ADS1115 Device.
+    /// Also available pre-packaged on an experimental board as KY-053. 
     /// </summary>
     public class ADS1115 : ADS1x15
     {
@@ -9,8 +12,8 @@ namespace Unosquare.RaspberryIO.Peripherals
         /// Initializes a new instance of the <see cref="ADS1115"/> class.
         /// </summary>
         /// <param name="address">The I2C Address for this device.</param>
-        public ADS1115(byte address = ADS1x15ADDRESS)
-            : base(ADS1115CONVERSIONDELAY, 0, address)
+        public ADS1115(II2CDevice device)
+            : base(device, ADS1015CONVERSIONDELAY, 0)
         {
         }
     }

--- a/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Button.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Extra/Extra.Button.cs
@@ -10,7 +10,7 @@ namespace Unosquare.RaspberryIO.Playground.Extra
         {
             Console.Clear();
 
-            var inputPin = Pi.Gpio[BcmPin.Gpio12];
+            var inputPin = Pi.Gpio[BcmPin.Gpio24];
             var button = new Button(inputPin, GpioPinResistorPullMode.PullUp);
 
             button.Pressed += (s, e) => LogMessageOnEvent("Pressed");

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Adc.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.Adc.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Unosquare.RaspberryIO.Abstractions;
+using Unosquare.RaspberryIO.Peripherals;
+
+namespace Unosquare.RaspberryIO.Playground.Peripherals
+{
+    public static partial class Peripherals
+    {
+        /// <summary>
+        /// Test the ADS1115 ADC (or the KY-053 sensor module) together with a two-axis analog joystick (KY-023 module)
+        /// Connect the joystick with the ADC as described in http://sensorkit.joy-it.net/index.php?title=KY-023_Joystick_Modul_(XY-Achsen).
+        /// Note that I2C-Bus support must be enabled in config. 
+        /// </summary>
+        public static void TestJoystick()
+        {
+            Console.Clear();
+
+            // Add device
+            var device = Pi.I2C.AddDevice(ADS1015.ADS1x15ADDRESS);
+
+            // The joystick module we're testing has also an extra digital signal when it is pressed down
+            var inputPin = Pi.Gpio[Abstractions.BcmPin.Gpio24];
+
+            inputPin.PinMode = GpioPinDriveMode.Input;
+
+            // For some reason, this command doesn't do anything right now. To set the pull-up mode, run the python KY-023 sample first. 
+            inputPin.InputPullMode = GpioPinResistorPullMode.PullUp; 
+
+            Console.WriteLine(ExitMessage);
+            var adc = new ADS1115(device);
+            while (true)
+            {
+                var a0 = adc.ReadChannel(0);
+                var a1 = adc.ReadChannel(1);
+                var a2 = adc.ReadChannel(2); // This 3rd channel can be connected to 3.3V or 0V to see that the reference values are converted correctly. 
+                bool pressed = inputPin.Read();
+                Console.WriteLine($"Button {(pressed ? "pressed" : "not pressed")}\nX:{a0}\nY:{a1}\nReference:{a2}");
+                if (Console.KeyAvailable)
+                {
+                    var input = Console.ReadKey(true).Key;
+                    if (input == ConsoleKey.Escape)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.cs
+++ b/src/Unosquare.RaspberryIO.Playground/Peripherals/Peripherals.cs
@@ -14,6 +14,7 @@ namespace Unosquare.RaspberryIO.Playground.Peripherals
             { ConsoleKey.I, "Infrared Sensor" },
             { ConsoleKey.R, "Rfid Controller" },
             { ConsoleKey.U, "Ultrasonic Sensor" },
+            { ConsoleKey.J, "Joystick" },
             { ConsoleKey.T, "Temperature and Humidity Sensor" },
         };
 
@@ -42,6 +43,9 @@ namespace Unosquare.RaspberryIO.Playground.Peripherals
                         break;
                     case ConsoleKey.T:
                         TestTempSensor();
+                        break;
+                    case ConsoleKey.J:
+                        TestJoystick();
                         break;
                     case ConsoleKey.Escape:
                         exit = true;


### PR DESCRIPTION
Now returns voltages, as specified by the docs.
(... and as with the python sample as well).

Also adapted the constructors to take the 
reference to the I2C device instead of instantiating
their own device. 