### PR TITLE
Netcoreapp3.0 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We offer an additional package with helpful classes to use peripherals, many of 
 
 ## Breaking changes
 
-### Version &ge; 0.24.0
+### Version &gt; 0.24.0
 
 This version requires .NET core 3.0 to build and run. 
 
@@ -106,6 +106,8 @@ PM> Install-Package Unosquare.WiringPi
 ```
 
 _**Note:**_ For now, we have fully implemented the [WiringPi](https://www.nuget.org/packages/Unosquare.wiringpi) library and we are working in the [PiGpio](https://github.com/unosquare/pigpio-dotnet/) implementation.
+
+_**Note:**_ The latest development builds require .NET core 3.0 to build and run. You should upgrade to the latest Version of Visual Studio first. 
 
 Install Raspberry.IO Peripherals package (Optional):
 [![NuGet version](https://badge.fury.io/nu/Unosquare.RaspberryIO.Peripherals.svg)](https://badge.fury.io/nu/Unosquare.RaspberryIO.Peripherals)
@@ -146,8 +148,19 @@ $ sudo tar -xvf dotnet-sdk-3.0.100-linux-arm.tar.gz -C /opt/dotnet/
 $ sudo ln -s /opt/dotnet/dotnet /usr/local/bin
 ```
 
-Now, verify your version of .Net Core by running ```dotnet --info```.
-Visit https://aka.ms/dotnet-download to check for newer versions of the .Net Core runtime (or SDK). 
+If you want to install just the runtime, use the following commands:
+
+```
+$ sudo apt-get -y update
+$ sudo apt-get -y install libunwind8 gettext
+$ wget https://download.visualstudio.microsoft.com/download/pr/0c5e013b-fa57-44dc-85bf-746885181278/58647e532fcc3a45209c13cdfbf30c74/dotnet-runtime-3.0.0-linux-arm.tar.gz
+$ sudo mkdir /opt/dotnet
+$ sudo tar -xvf dotnet-runtime-3.0.0-linux-arm.tar.gz -C /opt/dotnet/
+$ sudo ln 
+```
+
+Now, verify your version of .Net Core by running ```dotnet --info```. 
+Visit https://aka.ms/dotnet-download (or https://dotnet.microsoft.com/download/dotnet-core/3.0) to check for newer versions of the .Net Core runtime (or SDK). The Raspberry Pi running the default Raspbian OS needs the versions named "Linux ARM32". 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ We offer an additional package with helpful classes to use peripherals, many of 
 
 ## Breaking changes
 
+### Version &ge; 0.24.0
+
+This version requires .NET core 3.0 to build and run. 
+
 ### Version &ge; 0.18.0
 
 In the beginning, RaspberryIO was built around WiringPi library and all our classes, properties, enums, etc. was based on those ones used in WiringPi too.
@@ -129,16 +133,16 @@ sudo apt-get install mono-complete
 
 Now, verify your version of Mono by running ```mono --version```. Version 4.6 and above should be good enough.
 
-## Running .NET Core 2.2.6
+## Running .NET Core 3.0
 
-This project can also run in .NET Core. To install .Net Core 2.2.6 runtime please execute the following commands:
+This project can also run in .NET Core. To install .Net Core 3.0 sdk please execute the following commands:
 
 ```
 $ sudo apt-get -y update
 $ sudo apt-get -y install libunwind8 gettext
-$ wget https://download.visualstudio.microsoft.com/download/pr/428aaa32-f66c-4847-b845-aa21f90504e4/1cf033db866414997140c2672bd75069/dotnet-runtime-2.2.6-linux-arm.tar.gz
+$ wget https://download.visualstudio.microsoft.com/download/pr/8ddb8193-f88c-4c4b-82a3-39fcced27e91/b8e0b9bf4cf77dff09ff86cc1a73960b/dotnet-sdk-3.0.100-linux-arm.tar.gz
 $ sudo mkdir /opt/dotnet
-$ sudo tar -xvf dotnet-runtime-2.2.6-linux-arm.tar.gz -C /opt/dotnet/
+$ sudo tar -xvf dotnet-sdk-3.0.100-linux-arm.tar.gz -C /opt/dotnet/
 $ sudo ln -s /opt/dotnet/dotnet /usr/local/bin
 ```
 
@@ -246,6 +250,13 @@ Alternatively, you can use Visual Studio's Publish feature and a SCP (SSH Copy) 
     ```
       ubuntu@ubuntu:~/publish$ dotnet Unosquare.RaspberryIO.Playground.dll
     ```
+    or 
+    
+    ```
+      ubuntu@ubuntu:~/publish$ chmod +x Unosquare.RaspberryIO.Playground
+      ubuntu@ubuntu:~/publish$ ./Unosquare.RaspberryIO.Playground
+    ```
+    (the first line only needs to be executed once or after an update, since copying may not automatically set the execute bit)
 
     **_Note_**: Depending on the underlying library, you may need to use root user privileges to run the app.
 

--- a/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1x15.cs
+++ b/src/Unosquare.RaspberryIO.Peripherals/ADC/ADS1x15.cs
@@ -27,10 +27,10 @@ namespace Unosquare.RaspberryIO.Peripherals
         /// <param name="shift">bits to shift for sign correction.</param>
         protected ADS1x15(II2CDevice device, byte delay, byte shift)
         {
+            _device = device ?? throw new ArgumentNullException(nameof(device));
             _i2CAddress = (byte)device.DeviceId;
             _conversionDelay = delay;
             _bitShift = shift;
-            _device = device ?? throw new ArgumentNullException(nameof(device));
             Gain = AdsGain.GAINONE; 
         }
 

--- a/src/Unosquare.RaspberryIO.Playground/Properties/PublishProfiles/Linux-ARM-Netcore-Debug.pubxml
+++ b/src/Unosquare.RaspberryIO.Playground/Properties/PublishProfiles/Linux-ARM-Netcore-Debug.pubxml
@@ -7,10 +7,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>Any CPU</Platform>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <PublishDir>bin\Debug\netcoreapp2.2\linux-arm\publish\</PublishDir>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <PublishDir>bin\Debug\netcoreapp3.0\linux-arm\publish\</PublishDir>
     <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
-    <_IsPortable>true</_IsPortable>
   </PropertyGroup>
 </Project>

--- a/src/Unosquare.RaspberryIO.Playground/Properties/PublishProfiles/Linux-ARM-Netcore-Release.pubxml
+++ b/src/Unosquare.RaspberryIO.Playground/Properties/PublishProfiles/Linux-ARM-Netcore-Release.pubxml
@@ -7,8 +7,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <PublishDir>bin\Release\netcoreapp2.2\linux-arm\publish\</PublishDir>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <PublishDir>bin\Release\netcoreapp3.0\linux-arm\publish\</PublishDir>
     <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hint: Instead of calling "dotnet Unosquare.RaspberryIO.Playground.dll", one
can now directly execute Unosquare.RaspberryIO.Playground, after setting the execute
permission bit.